### PR TITLE
Fixed pymc3 bugs with overlapping variable names

### DIFF
--- a/simpanel/_families.py
+++ b/simpanel/_families.py
@@ -1,0 +1,113 @@
+import numbers
+from copy import copy
+
+import theano.tensor as tt
+from pymc3.model import modelcontext
+from pymc3 import distributions as pm_dists
+
+__all__ = ['Normal', 'StudentT', 'Binomial', 'Poisson']
+
+# Define link functions
+
+# Hack as assigning a function in the class definition automatically binds
+# it as a method.
+
+
+class Identity(object):
+
+    def __call__(self, x):
+        return x
+
+identity = Identity()
+logit = tt.nnet.sigmoid
+inverse = tt.inv
+exp = tt.exp
+
+
+class Family(object):
+    """Base class for Family of likelihood distribution and link functions.
+    """
+    priors = {}
+    link = None
+    parent = None
+    likelihood = None
+
+    def __init__(self, **kwargs):
+        # Overwrite defaults
+        for key, val in kwargs.items():
+            if key == 'priors':
+                self.priors = copy(self.priors)
+                self.priors.update(val)
+            else:
+                setattr(self, key, val)
+
+    def _get_priors(self, name, model=None):
+        """Return prior distributions of the likelihood.
+
+        Returns
+        -------
+        dict : mapping name -> pymc3 distribution
+        """
+        model = modelcontext(model)
+        priors = {}
+        for key, val in self.priors.items():
+            if isinstance(val, numbers.Number):
+                priors[key] = val
+            else:
+                priors[key] = model.Var('{}_{}'.format(name, key), val)
+
+        return priors
+
+    def create_likelihood(self, y_est, y_data, name, model=None):
+        """Create likelihood distribution of observed data.
+
+        Parameters
+        ----------
+        y_est : theano.tensor
+            Estimate of dependent variable
+        y_data : array
+            Observed dependent variable
+        """
+        priors = self._get_priors(model=model, name=name)
+        # Wrap y_est in link function
+        priors[self.parent] = self.link(y_est)
+        return self.likelihood('{}_y'.format(name), observed=y_data, **priors)
+
+    def __repr__(self):
+        return """Family {klass}:
+    Likelihood   : {likelihood}({parent})
+    Priors       : {priors}
+    Link function: {link}.""".format(
+            klass=self.__class__,
+            likelihood=self.likelihood.__name__,
+            parent=self.parent, priors=self.priors,
+            link=self.link)
+
+
+class StudentT(Family):
+    link = identity
+    likelihood = pm_dists.StudentT
+    parent = 'mu'
+    priors = {'lam': pm_dists.HalfCauchy.dist(beta=10, testval=1.),
+              'nu': 1}
+
+
+class Normal(Family):
+    link = identity
+    likelihood = pm_dists.Normal
+    parent = 'mu'
+    priors = {'sd': pm_dists.HalfCauchy.dist(beta=10, testval=1.)}
+
+
+class Binomial(Family):
+    link = logit
+    likelihood = pm_dists.Bernoulli
+    parent = 'p'
+    priors = {'p': pm_dists.Beta.dist(alpha=1, beta=1)}
+
+
+class Poisson(Family):
+    link = exp
+    likelihood = pm_dists.Poisson
+    parent = 'mu'
+    priors = {'mu': pm_dists.HalfCauchy.dist(beta=10, testval=1.)}

--- a/simpanel/_glm.py
+++ b/simpanel/_glm.py
@@ -1,0 +1,151 @@
+import numpy as np
+from pymc3.distributions import Normal
+from pymc3.model import modelcontext
+import patsy
+import theano
+from collections import defaultdict
+
+
+import simpanel._families as families
+
+__all__ = ['glm', 'linear_component', 'plot_posterior_predictive']
+
+
+def linear_component(name, formula, data, priors=None,
+                     intercept_prior=None,
+                     regressor_prior=None,
+                     init_vals=None,
+                     model=None):
+    """Create linear model according to patsy specification.
+
+    Parameters
+    ----------
+    formula : str
+        Patsy linear model descriptor.
+    data : array
+        Labeled array (e.g. pandas DataFrame, recarray).
+    priors : dict
+        Mapping prior name to prior distribution.
+        E.g. {'Intercept': Normal.dist(mu=0, sd=1)}
+    intercept_prior : pymc3 distribution
+        Prior to use for the intercept.
+        Default: Normal.dist(mu=0, tau=1.0E-12)
+    regressor_prior : pymc3 distribution
+        Prior to use for all regressor(s).
+        Default: Normal.dist(mu=0, tau=1.0E-12)
+    init_vals : dict
+        Set starting values externally: parameter -> value
+        Default: None
+    family : statsmodels.family
+        Link function to pass to statsmodels (init has to be True).
+    See `statsmodels.api.families`
+        Default: identity
+
+    Output
+    ------
+    (y_est, coeffs) : Estimate for y, list of coefficients
+
+    Example
+    -------
+    # Logistic regression
+    y_est, coeffs = glm('male ~ height + weight',
+                        htwt_data,
+                        family=glm.families.Binomial(link=glm.family.logit))
+    y_data = Bernoulli('y', y_est, observed=data.male)
+    """
+    if intercept_prior is None:
+        intercept_prior = Normal.dist(mu=0, tau=1.0E-12)
+    if regressor_prior is None:
+        regressor_prior = Normal.dist(mu=0, tau=1.0E-12)
+
+    if priors is None:
+        priors = defaultdict(None)
+
+    # Build patsy design matrix and get regressor names.
+    _, dmatrix = patsy.dmatrices(formula, data)
+    reg_names = dmatrix.design_info.column_names
+
+    if init_vals is None:
+        init_vals = {}
+
+    # Create individual coefficients
+    model = modelcontext(model)
+    coeffs = []
+
+    if reg_names[0] == 'Intercept':
+        prior = priors.get('Intercept', intercept_prior)
+        coeff = model.Var(reg_names.pop(0), prior)
+        if 'Intercept' in init_vals:
+            coeff.tag.test_value = init_vals['Intercept']
+        coeffs.append(coeff)
+
+    for reg_name in reg_names:
+        prior = priors.get(reg_name, regressor_prior)
+        coeff = model.Var('{}_{}'.format(name, reg_name), prior)
+        if reg_name in init_vals:
+            coeff.tag.test_value = init_vals[reg_name]
+        coeffs.append(coeff)
+
+    y_est = theano.dot(np.asarray(dmatrix),
+                       theano.tensor.stack(*coeffs)).reshape((1, -1))
+
+    return y_est, coeffs
+
+
+def glm(name, formula, data,
+        priors=None,
+        intercept_prior=None,
+        regressor_prior=None,
+        init_vals=None,
+        family=None,
+        model=None):
+    """Create GLM after Patsy model specification string.
+
+    Parameters
+    ----------
+    formula : str
+        Patsy linear model descriptor.
+    data : array
+        Labeled array (e.g. pandas DataFrame, recarray).
+    priors : dict
+        Mapping prior name to prior distribution.
+        E.g. {'Intercept': Normal.dist(mu=0, sd=1)}
+    intercept_prior : pymc3 distribution
+        Prior to use for the intercept.
+        Default: Normal.dist(mu=0, tau=1.0E-12)
+    regressor_prior : pymc3 distribution
+        Prior to use for all regressor(s).
+        Default: Normal.dist(mu=0, tau=1.0E-12)
+    init_vals : dict
+        Set starting values externally: parameter -> value
+        Default: None
+    family : Family object
+        Distribution of likelihood, see pymc3.glm.families
+        (init has to be True).
+
+    Output
+    ------
+    vars : List of created random variables (y_est, coefficients etc)
+
+    Example
+    -------
+    # Logistic regression
+    vars = glm('male ~ height + weight',
+               data,
+               family=glm.families.Binomial(link=glm.families.logit))
+    """
+
+    family = family or families.Normal(name=name)
+
+    y_data = np.asarray(patsy.dmatrices(formula, data)[0]).T
+
+    y_est, coeffs = linear_component(
+        name, formula, data,
+        priors=priors,
+        intercept_prior=intercept_prior,
+        regressor_prior=regressor_prior,
+        init_vals=init_vals,
+        model=model)
+    family.create_likelihood(y_est, y_data, name=name)
+
+    return y_est, coeffs

--- a/simpanel/glm.py
+++ b/simpanel/glm.py
@@ -19,13 +19,13 @@ class Glm(object):
                  **kwargs):
 
         families = dict(
-            normal=glm.families.Normal(),
-            student=glm.families.StudentT(),
-            binomial=glm.families.Binomial(),
-            poisson=glm.families.Poisson()
+            normal=glm.families.Normal,
+            student=glm.families.StudentT,
+            binomial=glm.families.Binomial,
+            poisson=glm.families.Poisson
         )
         if isinstance(family, str):
-            family = families[family]
+            family = families[family]()
 
         res = glm.glm(formula,
                       data,

--- a/simpanel/glm.py
+++ b/simpanel/glm.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-import numpy as np
 import pymc3 as pm
 import simpanel._glm as glm
 from simpanel._families import Normal, StudentT, Poisson, Binomial
@@ -11,14 +10,13 @@ class Glm(object):
     advifit = None
     trace = None
 
-    def __init__(self, formula, data,
+    def __init__(self, name, formula, data,
                  priors=None,
                  intercept_prior=None,
                  regressor_prior=None,
                  init_vals=None,
                  family='normal',
-                 model=None,
-                 name='glm_model'
+                 model=None
                  ):
         families = dict(
             normal=Normal,
@@ -44,14 +42,14 @@ class Glm(object):
         self.coefs = coefs
 
     @classmethod
-    def from_xy(cls, X, y,
+    def from_xy(cls, name, X, y,
                 priors=None,
                 intercept_prior=None,
                 regressor_prior=None,
                 init_vals=None,
                 family='normal',
-                model=None,
-                name='glm_model'):
+                model=None
+                ):
         import patsy
         import pandas as pd
 
@@ -67,15 +65,14 @@ class Glm(object):
             [patsy.Term([patsy.LookupFactor(y.name)])],
             [patsy.Term([patsy.LookupFactor(p)]) for p in X.columns]
         )
-        return cls(formula=formula,
-                   data=data,
+        return cls(name, formula, data,
                    priors=priors,
                    intercept_prior=intercept_prior,
                    regressor_prior=regressor_prior,
                    init_vals=init_vals,
                    family=family,
-                   model=model,
-                   name=name)
+                   model=model
+                   )
 
     def advi(self, **kwargs):
         self.advifit = pm.advi(**kwargs)

--- a/simpanel/panel.py
+++ b/simpanel/panel.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+import pandas as pd
+from simpanel.glm import Glm
+
+
+class SimPanel(object):
+    def __init__(self, X, y, groupid, sim):
+        if (not isinstance(X, pd.DataFrame) or
+                not isinstance(y, pd.Series)):
+            raise TypeError('Please provide X as pd.DataFrame and y as pd.Series')
+        full = pd.concat([X, y], 1)  # type: pd.DataFrame
+        full.set_index(groupid, append=True, inplace=True)
+        self.groups = dict()
+        for label, df in full.groupby(level=groupid):
+            self.groups[label] = df
+
+    @property
+    def data(self):
+        return pd.concat(self.groups.values())

--- a/simpanel/panel.py
+++ b/simpanel/panel.py
@@ -1,18 +1,28 @@
 # coding=utf-8
+from collections import OrderedDict
 import pandas as pd
+import pymc3 as pm
 from simpanel.glm import Glm
 
 
 class SimPanel(object):
-    def __init__(self, X, y, groupid, sim):
+    def __init__(self, name, X, y, sim, idindex=None, idcol=None):
         if (not isinstance(X, pd.DataFrame) or
                 not isinstance(y, pd.Series)):
             raise TypeError('Please provide X as pd.DataFrame and y as pd.Series')
+        if idcol is None or idindex is None:
+            raise ValueError('Please provide idcol or idindex')
+        self.name = name
+        self.groups = OrderedDict()
+        self.advifits = OrderedDict()
         full = pd.concat([X, y], 1)  # type: pd.DataFrame
-        full.set_index(groupid, append=True, inplace=True)
-        self.groups = dict()
-        for label, df in full.groupby(level=groupid):
+        level = idindex
+        if idcol:
+            full.set_index(idcol, append=True, inplace=True)
+            level = idcol
+        for label, df in full.groupby(level=level):
             self.groups[label] = df
+        self.sim = sim
 
     @property
     def data(self):

--- a/tests/test_glm.py
+++ b/tests/test_glm.py
@@ -25,19 +25,37 @@ class TestGlm(unittest.TestCase):
             [patsy.Term([patsy.LookupFactor(p)]) for p in self.X.columns]
         )
         with pm.Model():
-            _ = Glm(formula, self.mdata)
+            _ = Glm('glm', formula, self.mdata)
 
     def test_init_from_xy(self):
         import numpy as np
         with pm.Model():
-            _ = Glm.from_xy(self.X, self.y)
+            _ = Glm.from_xy('glm', self.X, self.y)
         with pm.Model():
-            _ = Glm.from_xy(np.asarray(self.X), self.y)
+            _ = Glm.from_xy('glm', np.asarray(self.X), self.y)
         with pm.Model():
-            _ = Glm.from_xy(self.X, np.asarray(self.y))
+            _ = Glm.from_xy('glm', self.X, np.asarray(self.y))
         with pm.Model():
-            _ = Glm.from_xy(np.asarray(self.X), np.asarray(self.y))
+            _ = Glm.from_xy('glm', np.asarray(self.X), np.asarray(self.y))
 
+    def test_advi(self):
+        with pm.Model():
+            aus = self.data.ix[self.data.Country == 'Australia', :-1]
+            g = Glm.from_xy('glm', aus.iloc[:, 1:], aus.iloc[:, 0])
+            fit = g.advi(verbose=False)
+        self.assertTrue(all(fit.means.values()))
+
+    def test_nuts(self):
+        with pm.Model():
+            aus = self.data.ix[self.data.Country == 'Australia', :-1]
+            g = Glm.from_xy('glm', aus.iloc[:, 1:], aus.iloc[:, 0])
+            trace = g.nuts(draws=10)
+        self.assertTrue(all(trace))
+
+    def test_name_does_not_overlaps(self):
+        with pm.Model():
+            _ = Glm.from_xy('glm1', self.X, self.y)
+            _ = Glm.from_xy('glm2', self.X, self.y)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now you should add `name` as first argument to Glm initialisation like `Glm(name, ...)`